### PR TITLE
Fix bedrock typo in notebook

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -841,7 +841,7 @@
    "id": "88d8106c-44cf-48a9-91d0-3b8bd987273b",
    "metadata": {},
    "source": [
-    "### Get 10-K Text Embeddings with Vertex AI\n",
+    "### Get 10-K Text Embeddings with Bedrock\n",
     "Now that we understand our data and how to chunk it. Let's Generate embeddings.\n"
    ]
   },
@@ -1341,7 +1341,7 @@
     "### Generate Cypher\n",
     "Both Bedrock and Neo4j support LangChain.  We will be using LangChain to quickly convert English to Cypher and then executes it on Neo4j.  This is augmented using generative AI before sending the response to the user.  This makes graph consumption easier for non-cypher experts.\n",
     "\n",
-    "The diagram below shows how Neo4j and Vertex AI will interact using LangChain.\n",
+    "The diagram below shows how Neo4j and Bedrock will interact using LangChain.\n",
     "\n",
     "![langchain-neo4j.png](attachment:f7d780bc-367c-48f7-b076-f4944ab5160d.png)\n",
     "\n",
@@ -2083,9 +2083,9 @@
   },
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 3.0)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2097,7 +2097,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   },
   "toc-autonumbering": true,
   "toc-showcode": false,


### PR DESCRIPTION
Found a typo where it says Vertex instead of Bedrock in 2 markdown cells.