### PR TITLE
Updating ENV Variable Template For Streamlit App

### DIFF
--- a/ui/streamlit/.streamlit/secrets.toml.example
+++ b/ui/streamlit/.streamlit/secrets.toml.example
@@ -1,5 +1,5 @@
-SERVICE_NAME = "" #e.g. bedrock
-REGION_NAME = "" #e.g. us-west-2
+SERVICE_NAME = "bedrock-runtime" #e.g. bedrock-runtime
+REGION_NAME = "us-west-2" #e.g. us-west-2
 CYPHER_MODEL = "" #e.g. anthropic.claude-v2
 ACCESS_KEY = "AWS ACCESS KEY"
 SECRET_KEY = "AWS SECRET KEY"


### PR DESCRIPTION
This avoids some eventual confusion/pain. Users should use "bedrock-runtime" not "bedrock" for the service...otherwise, they will get a confusing error `Error raised by bedrock service: 'Bedrock' object has no attribute 'invoke_model`