### PR TITLE
Fixing Cypher Gen Prompt and Cleaning up Pip Installs

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -48,10 +48,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --user --no-build-isolation --force-reinstall \\\n",
-    "    \"boto3>=1.28.57\" \\\n",
-    "    \"awscli>=1.29.57\" \\\n",
-    "    \"botocore>=1.31.57\""
+    "%pip install boto3 awscli botocore"
    ]
   },
   {
@@ -71,12 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --user \"langchain==0.0.314\"\n",
-    "%pip install --user graphdatascience\n",
-    "%pip install --user pydantic\n",
-    "%pip install --user IProgress\n",
-    "%pip install --user tqdm\n",
-    "%pip install --user gradio"
+    "%pip install langchain graphdatascience pydantic IProgress tqdm gradio ipywidgets"
    ]
   },
   {
@@ -1362,7 +1354,8 @@
     "from langchain.llms.bedrock import Bedrock\n",
     "from langchain.prompts.prompt import PromptTemplate\n",
     "\n",
-    "CYPHER_GENERATION_TEMPLATE = \"\"\"Human: You are an expert Neo4j Cypher translator who understands the question in english and convert to Cypher strictly based on the Neo4j Schema provided and following the instructions below:\n",
+    "CYPHER_GENERATION_TEMPLATE = \"\"\"Human:\n",
+    "You are an expert Neo4j Cypher translator who understands the question in english and convert to Cypher strictly based on the Neo4j Schema provided and following the instructions below:\n",
     "1. Generate Cypher query compatible ONLY for Neo4j Version 5\n",
     "2. Do not use EXISTS, SIZE keywords in the cypher. Use alias when using the WITH keyword\n",
     "3. Use only Nodes and relationships mentioned in the schema\n",
@@ -1372,9 +1365,15 @@
     "7. Cypher is NOT SQL. So, do not mix and match the syntaxes\n",
     "Strictly use this Schema for CYpher generation:\n",
     "{schema}\n",
+    "\n",
+    "Assistant:\n",
+    "Understood. I will convert the following question to Cypher strictly based on the Neo4j schema and instructions provided.\n",
+    "\n",
     "Human: {question}\n",
+    "\n",
     "Assistant:\n",
     "\"\"\"\n",
+    "\n",
     "CYPHER_GENERATION_PROMPT = PromptTemplate(\n",
     "    input_variables=[\"schema\", \"question\"], template=CYPHER_GENERATION_TEMPLATE\n",
     ")\n",


### PR DESCRIPTION
For the Cypher Gen prompt, you just need to make sure you alternate between "Human:" and "Assistant:" to avoid the warning/Error thing.  Before there were two "Human:"  statements in a row. You will probs need to make the same change in the UI. 

I also cleaned up the imports. I used the base Python 3.10 image in SageMaker and this worked....up to you.  
1. I would avoid stuff like `--no-build-isolation` and  --force-reinstall` if possible
 I would avoid version freezes if possible
2. I don't think `--user` is necessary when also using the magic syntax `%pip`. When you use the syntax `!pip` then pip is run in the OS terminal outside the notebook session and I think this could be an issue. However, when you use `%pip` the command is run inside the session/kernel as the user of the notebook....at least that is my understanding.
3. I would avoid fixing versions of dependencies where possible for demos like these.....since as things change it can create more issues down the road. 